### PR TITLE
Add verification to AddExerciseToWorkout_NonExistingWorkout test

### DIFF
--- a/RepTrack/RepTrackTests/Business/Services/WorkoutSessionServiceTests.cs
+++ b/RepTrack/RepTrackTests/Business/Services/WorkoutSessionServiceTests.cs
@@ -408,6 +408,8 @@ namespace RepTrackTests.Business.Services
             // Act & Assert
             await Assert.ThrowsAsync<NotFoundException>(() =>
                 _workoutService.AddExerciseToWorkoutAsync(_workoutId, 1, "Notes", _userId));
+
+            _mockUnitOfWork.Verify(uow => uow.CompleteAsync(), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- assert that `CompleteAsync` is never called when adding an exercise to a non-existing workout

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a1aca96c832e91073e19229ce2be